### PR TITLE
extend with crd client

### DIFF
--- a/k8scrdclient/spec.go
+++ b/k8scrdclient/spec.go
@@ -1,0 +1,13 @@
+package k8scrdclient
+
+import (
+	"context"
+
+	"github.com/giantswarm/backoff"
+	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
+)
+
+type Interface interface {
+	EnsureCreated(ctx context.Context, customResource *apiextensionsv1beta1.CustomResourceDefinition, backOff backoff.Interface) error
+	EnsureDeleted(ctx context.Context, customResource *apiextensionsv1beta1.CustomResourceDefinition, backOff backoff.Interface) error
+}

--- a/setup.go
+++ b/setup.go
@@ -11,8 +11,6 @@ import (
 	apiextensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-
-	"github.com/giantswarm/k8sclient/k8scrdclient"
 )
 
 type SetupConfig struct {
@@ -42,21 +40,9 @@ func NewSetup(config SetupConfig) (*Setup, error) {
 }
 
 func (s *Setup) EnsureCRDCreated(ctx context.Context, crd *apiextensionsv1beta1.CustomResourceDefinition) error {
-	var err error
-
-	var crdClient *k8scrdclient.CRDClient
-	{
-		c := k8scrdclient.Config{
-			K8sExtClient: s.clients.ExtClient(),
-			Logger:       s.logger,
-		}
-
-		crdClient, err = k8scrdclient.New(c)
-	}
-
 	b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
 
-	err = crdClient.EnsureCreated(ctx, crd, b)
+	err := s.clients.CRDClient().EnsureCreated(ctx, crd, b)
 	if err != nil {
 		return microerror.Mask(err)
 	}
@@ -65,21 +51,9 @@ func (s *Setup) EnsureCRDCreated(ctx context.Context, crd *apiextensionsv1beta1.
 }
 
 func (s *Setup) EnsureCRDDeleted(ctx context.Context, crd *apiextensionsv1beta1.CustomResourceDefinition) error {
-	var err error
-
-	var crdClient *k8scrdclient.CRDClient
-	{
-		c := k8scrdclient.Config{
-			K8sExtClient: s.clients.ExtClient(),
-			Logger:       s.logger,
-		}
-
-		crdClient, err = k8scrdclient.New(c)
-	}
-
 	b := backoff.NewExponential(backoff.ShortMaxWait, backoff.ShortMaxInterval)
 
-	err = crdClient.EnsureDeleted(ctx, crd, b)
+	err := s.clients.CRDClient().EnsureDeleted(ctx, crd, b)
 	if err != nil {
 		return microerror.Mask(err)
 	}

--- a/spec.go
+++ b/spec.go
@@ -6,9 +6,12 @@ import (
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
+
+	"github.com/giantswarm/k8sclient/k8scrdclient"
 )
 
 type Interface interface {
+	CRDClient() k8scrdclient.Interface
 	DynClient() dynamic.Interface
 	ExtClient() apiextensionsclient.Interface
 	G8sClient() versioned.Interface


### PR DESCRIPTION
This bundles up more clients which makes configuration in e.g. `operatorkit` way more easy. This also cleans up some code. It is questionable to me how useful the setup magic now is with the simple redirect to the CRD Client. But I did not want to change too much now. 