### PR TITLE
Fix import in k8srestconfig example usage

### DIFF
--- a/k8srestconfig/k8s_rest_config.go
+++ b/k8srestconfig/k8s_rest_config.go
@@ -8,8 +8,8 @@
 //		"k8s.io/client-go/rest"
 //		apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 //
-//		"github.com/giantswarm/operatorkit/client/k8srestconfig"
 //		"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+//		"github.com/giantswarm/k8sclient/k8srestconfig"
 //		"github.com/giantswarm/microerror"
 //	)
 //


### PR DESCRIPTION
k8srestconfig was extracted to k8sclient from operatorkit. This PR fixes godoc with example k8srestconfig usage to import k8srestconfig from k8sclient project and not operatorkit.