### PR TITLE
configure controller client properly with scheme and mapper

### DIFF
--- a/spec.go
+++ b/spec.go
@@ -3,6 +3,7 @@ package k8sclient
 import (
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -20,4 +21,5 @@ type Interface interface {
 	K8sClient() kubernetes.Interface
 	RESTClient() rest.Interface
 	RESTConfig() *rest.Config
+	Scheme() *runtime.Scheme
 }


### PR DESCRIPTION
This is a ~breaking~ (made it optional due to handling of native types like config maps) change we are required to do in our current setup. The controller client needs to be configured properly in the first place. This is nothing we can do somewhere else under the hood. The current situation in `operatorkit` requires this. 