### PR TITLE
Deepcopy restconfig before passing it to DynamicRESTMapper

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -110,7 +110,7 @@ func NewClients(config ClientsConfig) (*Clients, error) {
 		// we want to separate client and manager. Thus we configure the client here
 		// properly on our own instead of relying on the manager to provide a
 		// client, which might change in the future.
-		mapper, err := apiutil.NewDynamicRESTMapper(restConfig)
+		mapper, err := apiutil.NewDynamicRESTMapper(rest.CopyConfig(restConfig))
 		if err != nil {
 			return nil, microerror.Mask(err)
 		}


### PR DESCRIPTION
RestConfig contains rate limiter among other things and therefore shouldn't be
shared between clients but deep copied instead.