### PR TITLE
Pass SchemeBuilder to support adding multiple schemes

### DIFF
--- a/clients.go
+++ b/clients.go
@@ -18,10 +18,10 @@ import (
 )
 
 type ClientsConfig struct {
-	// AddToScheme is an optional way to extend the known types to the gobal
+	Logger micrologger.Logger
+	// SchemeBuilder is an optional way to extend the known types to the global
 	// client-go scheme. Make use of it for custom CRs.
-	AddToScheme func(*runtime.Scheme) error
-	Logger      micrologger.Logger
+	SchemeBuilder runtime.SchemeBuilder
 
 	// KubeConfigPath and RestConfig are mutually exclusive.
 	KubeConfigPath string
@@ -93,11 +93,11 @@ func NewClients(config ClientsConfig) (*Clients, error) {
 
 	var ctrlClient client.Client
 	{
-		if config.AddToScheme != nil {
+		if config.SchemeBuilder != nil {
 			// Extend the global client-go scheme which is used by all the tools under
 			// the hood. The scheme is required for the controller-runtime controller to
 			// be able to watch for runtime objects of a certain type.
-			err = config.AddToScheme(scheme.Scheme)
+			err = config.SchemeBuilder.AddToScheme(scheme.Scheme)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}

--- a/clients.go
+++ b/clients.go
@@ -21,7 +21,7 @@ type ClientsConfig struct {
 	Logger micrologger.Logger
 	// SchemeBuilder is an optional way to extend the known types to the global
 	// client-go scheme. Make use of it for custom CRs.
-	SchemeBuilder []func(*runtime.Scheme) error
+	SchemeBuilder SchemeBuilder
 
 	// KubeConfigPath and RestConfig are mutually exclusive.
 	KubeConfigPath string

--- a/clients.go
+++ b/clients.go
@@ -97,7 +97,9 @@ func NewClients(config ClientsConfig) (*Clients, error) {
 			// Extend the global client-go scheme which is used by all the tools under
 			// the hood. The scheme is required for the controller-runtime controller to
 			// be able to watch for runtime objects of a certain type.
-			err = runtime.SchemeBuilder(config.SchemeBuilder).AddToScheme(scheme.Scheme)
+			schemeBuilder := runtime.SchemeBuilder(config.SchemeBuilder)
+
+			err = schemeBuilder.AddToScheme(scheme.Scheme)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}

--- a/clients.go
+++ b/clients.go
@@ -21,7 +21,7 @@ type ClientsConfig struct {
 	Logger micrologger.Logger
 	// SchemeBuilder is an optional way to extend the known types to the global
 	// client-go scheme. Make use of it for custom CRs.
-	SchemeBuilder runtime.SchemeBuilder
+	SchemeBuilder []func(*runtime.Scheme) error
 
 	// KubeConfigPath and RestConfig are mutually exclusive.
 	KubeConfigPath string
@@ -97,7 +97,7 @@ func NewClients(config ClientsConfig) (*Clients, error) {
 			// Extend the global client-go scheme which is used by all the tools under
 			// the hood. The scheme is required for the controller-runtime controller to
 			// be able to watch for runtime objects of a certain type.
-			err = config.SchemeBuilder.AddToScheme(scheme.Scheme)
+			err = runtime.SchemeBuilder(config.SchemeBuilder).AddToScheme(scheme.Scheme)
 			if err != nil {
 				return nil, microerror.Mask(err)
 			}

--- a/types.go
+++ b/types.go
@@ -4,4 +4,11 @@ import "k8s.io/apimachinery/pkg/runtime"
 
 // SchemeBuilder is an optional way to extend the known types to the global
 // client-go scheme. Make use of it for custom CRs.
+//
+// Typical usage:
+//
+//	k8sclient.SchemeBuilder{
+//		myapiversion.AddToShcheme,
+//	}
+//
 type SchemeBuilder []func(*runtime.Scheme) error

--- a/types.go
+++ b/types.go
@@ -1,0 +1,7 @@
+package k8sclient
+
+import "k8s.io/apimachinery/pkg/runtime"
+
+// SchemeBuilder is an optional way to extend the known types to the global
+// client-go scheme. Make use of it for custom CRs.
+type SchemeBuilder []func(*runtime.Scheme) error


### PR DESCRIPTION
See https://github.com/giantswarm/chart-operator/pull/321#discussion_r353200555

In chart-operator and maybe some other places we need to support adding multiple schemes. This changes the signature to take in a runtime.SchemeBuilder which is what the generated clients use.

https://github.com/giantswarm/apiextensions/blob/master/pkg/clientset/versioned/fake/register.go#L37-L59


