### PR TITLE
Add client-go DiscoveryClient to K8sClients

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -566,6 +566,7 @@
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/apimachinery/pkg/runtime",
+    "k8s.io/client-go/discovery",
     "k8s.io/client-go/dynamic",
     "k8s.io/client-go/kubernetes",
     "k8s.io/client-go/kubernetes/scheme",

--- a/spec.go
+++ b/spec.go
@@ -4,6 +4,7 @@ import (
 	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/dynamic"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -15,6 +16,7 @@ import (
 type Interface interface {
 	CRDClient() k8scrdclient.Interface
 	CtrlClient() client.Client
+	DiscoveryClient() discovery.DiscoveryInterface
 	DynClient() dynamic.Interface
 	ExtClient() apiextensionsclient.Interface
 	G8sClient() versioned.Interface


### PR DESCRIPTION
DiscoveryClient provides interface to query k8s api for registered api groups,
resources and similar metadata that is necessary when dynamically manipulating
present types.

Example use-case for this is to discover different versions of present
Deployments so that those can be listed and patched for rolling restart.