### PR TITLE
Update microerror and micrologger dependencies

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -63,23 +63,23 @@
   revision = "4dd4911251929a0ac4c4f3d8c4bda482a9e09f30"
 
 [[projects]]
-  branch = "master"
-  digest = "1:d80347cb345b2986422040821735ae0efba8b8093b765b146b90796d926b85b4"
+  digest = "1:701a5f5a7297ced0c7b9aeeba6a40ef47663b956d56e7acd09fe0d1c31eb1e4b"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
   pruneopts = "UT"
-  revision = "e0ebc4ecf5a515b8f2a33257d08962e387120a77"
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
-  digest = "1:2275349e37657984a6cfc425803962b3f46843532b37b7a4552c5356086dffc6"
+  digest = "1:20fe82d087077d505e906c36177da3edb09897430812a437adb1dac497dc4371"
   name = "github.com/giantswarm/micrologger"
   packages = [
     ".",
     "loggermeta",
   ]
   pruneopts = "UT"
-  revision = "c87486c7d20d7878ad57a09d379d7d59328b472e"
-  version = "v0.1.0"
+  revision = "c4d217562e3d493e3ff571707346a5a2653475cb"
+  version = "v0.1.1"
 
 [[projects]]
   digest = "1:0cfcded8689c2c964c223650009c5dd9e283c22d57f18f2335aafa16cc22acf1"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -36,11 +36,11 @@
 
 [[constraint]]
   name = "github.com/giantswarm/microerror"
-  branch = "master"
+  version = "~0.1.0"
 
 [[constraint]]
   name = "github.com/giantswarm/micrologger"
-  version = "v0.1.0"
+  version = "~0.1.0"
 
 [[constraint]]
   name = "k8s.io/api"

--- a/vendor/github.com/giantswarm/microerror/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/microerror/CHANGELOG.md
@@ -1,0 +1,17 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] 2020-02-03
+
+### Added
+
+- First release.
+
+[Unreleased]: https://github.com/giantswarm/microerror/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/giantswarm/microerror/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
+++ b/vendor/github.com/giantswarm/micrologger/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.1] 2020-03-04
+
+### Changed
+
+- Updated microerror to `v0.1.0.
+
 ## [0.1.0] 2020-02-13
 
 ### Added
@@ -12,4 +18,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - First release.
 
 [Unreleased]: https://github.com/giantswarm/micrologger/compare/v0.1.0...HEAD
+[0.1.1]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.1
 [0.1.0]: https://github.com/giantswarm/micrologger/releases/tag/v0.1.0

--- a/vendor/github.com/giantswarm/micrologger/Gopkg.lock
+++ b/vendor/github.com/giantswarm/micrologger/Gopkg.lock
@@ -2,12 +2,12 @@
 
 
 [[projects]]
-  branch = "master"
-  digest = "1:9c432418e5180be62a4bf565761eb2c618fc4ff9b7efa9a260c92068f453e28a"
+  digest = "1:98e9dc8d46288ca1cbcd2925710b5fc684514ddba062e109f35a40ad5e81de8f"
   name = "github.com/giantswarm/microerror"
   packages = ["."]
   pruneopts = ""
-  revision = "a8d5d4f526c526b4b773062958847fe7e0b7f449"
+  revision = "e8fe0fa9c0097ca80d8b773e1d728843447f9233"
+  version = "v0.1.0"
 
 [[projects]]
   digest = "1:44ec1082ba97d89ce860abcc6ee3f0cf24e658d3efb8531b0f0a52f0781e4243"

--- a/vendor/github.com/giantswarm/micrologger/Gopkg.toml
+++ b/vendor/github.com/giantswarm/micrologger/Gopkg.toml
@@ -22,7 +22,7 @@
 
 
 [[constraint]]
-  branch = "master"
+  version = "~0.1.0"
   name = "github.com/giantswarm/microerror"
 
 [[constraint]]


### PR DESCRIPTION
We need to pin the micrologger dependency to the v0.1.0 version which is the one using dep instead of newer versions that use go modules.

