### PR TITLE
aligned import path with major version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Aligned import path with upcoming major version `v2.0.0`.
+
 
 
 ## [1.0.1] 2020-04-14

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/k8sclient/v1
+module github.com/giantswarm/k8sclient/v2
 
 go 1.14
 

--- a/go.sum
+++ b/go.sum
@@ -106,7 +106,6 @@ github.com/giantswarm/apiextensions v0.2.0 h1:6gnfXFRL/eGqPbYhM7jUckwmulx7jh6qJp
 github.com/giantswarm/apiextensions v0.2.0/go.mod h1:iw66G0WDcrQl9mi2m/6mov2fWTD6ZiT2+FC62b2Mczw=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
-github.com/giantswarm/k8sclient v1.0.0 h1:8qXs1p6w2lm7SEasCmJ8DhPSSe/clJaqeHeHnvps2C0=
 github.com/giantswarm/microerror v0.2.0 h1:SaE7S34mp/wEiQkgtPiq8wQbNUTCj1gjiCWPjO3wgJo=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
 github.com/giantswarm/micrologger v0.3.1 h1:HbYbQLobvfsLYzRiGTncaO61CCPd4BlT18xaaday+4o=

--- a/go.sum
+++ b/go.sum
@@ -106,6 +106,7 @@ github.com/giantswarm/apiextensions v0.2.0 h1:6gnfXFRL/eGqPbYhM7jUckwmulx7jh6qJp
 github.com/giantswarm/apiextensions v0.2.0/go.mod h1:iw66G0WDcrQl9mi2m/6mov2fWTD6ZiT2+FC62b2Mczw=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
+github.com/giantswarm/k8sclient v1.0.0 h1:8qXs1p6w2lm7SEasCmJ8DhPSSe/clJaqeHeHnvps2C0=
 github.com/giantswarm/microerror v0.2.0 h1:SaE7S34mp/wEiQkgtPiq8wQbNUTCj1gjiCWPjO3wgJo=
 github.com/giantswarm/microerror v0.2.0/go.mod h1:1YtJq/m7Vlq1Y6NP7B+SODOKCGlG7e5wctV2OoE9n34=
 github.com/giantswarm/micrologger v0.3.1 h1:HbYbQLobvfsLYzRiGTncaO61CCPd4BlT18xaaday+4o=

--- a/pkg/k8sclient/clients.go
+++ b/pkg/k8sclient/clients.go
@@ -14,7 +14,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	"github.com/giantswarm/k8sclient/v1/pkg/k8scrdclient"
+	"github.com/giantswarm/k8sclient/v2/pkg/k8scrdclient"
 )
 
 type ClientsConfig struct {

--- a/pkg/k8sclient/spec.go
+++ b/pkg/k8sclient/spec.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/k8sclient/v1/pkg/k8scrdclient"
+	"github.com/giantswarm/k8sclient/v2/pkg/k8scrdclient"
 )
 
 type Interface interface {

--- a/pkg/k8sclienttest/k8sclienttest.go
+++ b/pkg/k8sclienttest/k8sclienttest.go
@@ -10,7 +10,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/k8sclient/v1/pkg/k8scrdclient"
+	"github.com/giantswarm/k8sclient/v2/pkg/k8scrdclient"
 )
 
 type ClientsConfig struct {

--- a/pkg/k8scrdclient/k8scrdclient.go
+++ b/pkg/k8scrdclient/k8scrdclient.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/k8sclient/v1/pkg/k8sversion"
+	"github.com/giantswarm/k8sclient/v2/pkg/k8sversion"
 )
 
 type Config struct {


### PR DESCRIPTION
Oh stars, in order to get the imports straight and consistent I decided to use `/v2` because you cannot have the versioned import paths with `v1.x.x` tags. :wtf:

## Checklist

- [x] Update changelog in CHANGELOG.md.
