### PR TITLE
Use apiextensions v2 with 1.18 branch

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/giantswarm/k8sclient/v2
 go 1.14
 
 require (
-	github.com/giantswarm/apiextensions v0.4.17-0.20200723160042-89aed92d1080
+	github.com/giantswarm/apiextensions/v2 v2.1.0
 	github.com/giantswarm/backoff v0.2.0
 	github.com/giantswarm/microerror v0.2.0
 	github.com/giantswarm/micrologger v0.3.1

--- a/go.sum
+++ b/go.sum
@@ -127,8 +127,8 @@ github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWo
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/ghodss/yaml v0.0.0-20150909031657-73d445a93680/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
 github.com/ghodss/yaml v1.0.0/go.mod h1:4dBDuWmgqj2HViK6kFavaiC9ZROes6MMH2rRYeMEF04=
-github.com/giantswarm/apiextensions v0.4.17-0.20200723160042-89aed92d1080 h1:rDBHMvUVUxYvIgBpXmm6UHcMvca/bGH5zPX+0tlkaP8=
-github.com/giantswarm/apiextensions v0.4.17-0.20200723160042-89aed92d1080/go.mod h1:hHZdka5w2Q4m3eBYY+Ykrc+mB1xfOo+OO96aVIgMnac=
+github.com/giantswarm/apiextensions/v2 v2.1.0 h1:2KoU6Kj4Oc1DcMu652bvaET1q5aGmh4D2aTptL9a2Ng=
+github.com/giantswarm/apiextensions/v2 v2.1.0/go.mod h1:/qSx5jA2F5um0ipvVDMZJz+rJqsPZewzz4jjMXkXYFw=
 github.com/giantswarm/backoff v0.2.0 h1:kdfAf83pZ/l8X0KiA2dJ2Wq19nS9hISijVn7ZRdFhfU=
 github.com/giantswarm/backoff v0.2.0/go.mod h1:Z3WRsFilSJ5H5VlFa4XhraoPr+9pmZgYasoY2OSfNOk=
 github.com/giantswarm/microerror v0.2.0 h1:SaE7S34mp/wEiQkgtPiq8wQbNUTCj1gjiCWPjO3wgJo=

--- a/pkg/k8sclient/clients.go
+++ b/pkg/k8sclient/clients.go
@@ -1,7 +1,7 @@
 package k8sclient
 
 import (
-	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"

--- a/pkg/k8sclient/spec.go
+++ b/pkg/k8sclient/spec.go
@@ -1,7 +1,7 @@
 package k8sclient
 
 import (
-	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"

--- a/pkg/k8sclienttest/k8sclienttest.go
+++ b/pkg/k8sclienttest/k8sclienttest.go
@@ -1,7 +1,7 @@
 package k8sclienttest
 
 import (
-	"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"

--- a/pkg/k8srestconfig/k8s_rest_config.go
+++ b/pkg/k8srestconfig/k8s_rest_config.go
@@ -8,7 +8,7 @@
 //		"k8s.io/client-go/rest"
 //		apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 //
-//		"github.com/giantswarm/apiextensions/pkg/clientset/versioned"
+//		"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
 //		"github.com/giantswarm/k8sclient/k8srestconfig"
 //		"github.com/giantswarm/microerror"
 //	)


### PR DESCRIPTION
Preparing https://github.com/giantswarm/k8sclient/pull/99 for release v2.1.0.