### PR TITLE
Add fake clientset for testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Fake clientset for testing
+
 ## [4.0.0] - 2020-08-10
 
 ### Changed

--- a/pkg/k8sclient/clients.go
+++ b/pkg/k8sclient/clients.go
@@ -6,7 +6,6 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionsclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -59,24 +58,6 @@ func NewFakeClients(config ClientsConfig, objects ...runtime.Object) (*Clients, 
 		restConfig = config.RestConfig
 	}
 
-	var extClient apiextensionsclient.Interface
-	{
-		extClient = apiextensionsclientfake.NewSimpleClientset(objects...)
-	}
-
-	var crdClient *k8scrdclient.CRDClient
-	{
-		c := k8scrdclient.Config{
-			K8sExtClient: extClient,
-			Logger:       config.Logger,
-		}
-
-		crdClient, err = k8scrdclient.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
 	var ctrlClient client.Client
 	{
 		if config.SchemeBuilder != nil {
@@ -112,10 +93,8 @@ func NewFakeClients(config ClientsConfig, objects ...runtime.Object) (*Clients, 
 	c := &Clients{
 		logger: config.Logger,
 
-		crdClient:  crdClient,
 		ctrlClient: ctrlClient,
 		dynClient:  dynClient,
-		extClient:  extClient,
 		g8sClient:  g8sClient,
 		k8sClient:  k8sClient,
 		restConfig: restConfig,

--- a/pkg/k8sclient/clients.go
+++ b/pkg/k8sclient/clients.go
@@ -47,7 +47,7 @@ type Clients struct {
 	restConfig *rest.Config
 }
 
-func NewFakeClients(config ClientsConfig) (*Clients, error) {
+func NewFakeClients(config ClientsConfig, objects ...runtime.Object) (*Clients, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
@@ -61,7 +61,7 @@ func NewFakeClients(config ClientsConfig) (*Clients, error) {
 
 	var extClient apiextensionsclient.Interface
 	{
-		extClient = apiextensionsclientfake.NewSimpleClientset()
+		extClient = apiextensionsclientfake.NewSimpleClientset(objects...)
 	}
 
 	var crdClient *k8scrdclient.CRDClient
@@ -91,22 +91,22 @@ func NewFakeClients(config ClientsConfig) (*Clients, error) {
 			}
 		}
 
-		ctrlClient = clientfake.NewFakeClientWithScheme(scheme.Scheme)
+		ctrlClient = clientfake.NewFakeClientWithScheme(scheme.Scheme, objects...)
 	}
 
 	var dynClient dynamic.Interface
 	{
-		dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme)
+		dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme, objects...)
 	}
 
 	var g8sClient versioned.Interface
 	{
-		g8sClient = versionedfake.NewSimpleClientset()
+		g8sClient = versionedfake.NewSimpleClientset(objects...)
 	}
 
 	var k8sClient kubernetes.Interface
 	{
-		k8sClient = kubernetesfake.NewSimpleClientset()
+		k8sClient = kubernetesfake.NewSimpleClientset(objects...)
 	}
 
 	c := &Clients{

--- a/pkg/k8sclient/clients.go
+++ b/pkg/k8sclient/clients.go
@@ -6,6 +6,7 @@ import (
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
 	dynamicfake "k8s.io/client-go/dynamic/fake"
@@ -58,6 +59,24 @@ func NewFakeClients(config ClientsConfig, objects ...runtime.Object) (*Clients, 
 		restConfig = config.RestConfig
 	}
 
+	var extClient apiextensionsclient.Interface
+	{
+		extClient = apiextensionsclientfake.NewSimpleClientset()
+	}
+
+	var crdClient *k8scrdclient.CRDClient
+	{
+		c := k8scrdclient.Config{
+			K8sExtClient: extClient,
+			Logger:       config.Logger,
+		}
+
+		crdClient, err = k8scrdclient.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
 	var ctrlClient client.Client
 	{
 		if config.SchemeBuilder != nil {
@@ -82,7 +101,7 @@ func NewFakeClients(config ClientsConfig, objects ...runtime.Object) (*Clients, 
 
 	var g8sClient versioned.Interface
 	{
-		g8sClient = versionedfake.NewSimpleClientset(objects...)
+		g8sClient = versionedfake.NewSimpleClientset()
 	}
 
 	var k8sClient kubernetes.Interface
@@ -93,8 +112,10 @@ func NewFakeClients(config ClientsConfig, objects ...runtime.Object) (*Clients, 
 	c := &Clients{
 		logger: config.Logger,
 
+		crdClient:  crdClient,
 		ctrlClient: ctrlClient,
 		dynClient:  dynClient,
+		extClient:  extClient,
 		g8sClient:  g8sClient,
 		k8sClient:  k8sClient,
 		restConfig: restConfig,

--- a/pkg/k8sclient/clients.go
+++ b/pkg/k8sclient/clients.go
@@ -2,22 +2,17 @@ package k8sclient
 
 import (
 	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
-	versionedfake "github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned/fake"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
-	apiextensionsclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
-	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
-	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
-	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	"github.com/giantswarm/k8sclient/v4/pkg/k8scrdclient"
 )
@@ -45,83 +40,6 @@ type Clients struct {
 	k8sClient  kubernetes.Interface
 	restClient rest.Interface
 	restConfig *rest.Config
-}
-
-func NewFakeClients(config ClientsConfig, objects ...runtime.Object) (*Clients, error) {
-	if config.Logger == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
-	}
-
-	var err error
-
-	var restConfig *rest.Config
-	{
-		restConfig = config.RestConfig
-	}
-
-	var extClient apiextensionsclient.Interface
-	{
-		extClient = apiextensionsclientfake.NewSimpleClientset()
-	}
-
-	var crdClient *k8scrdclient.CRDClient
-	{
-		c := k8scrdclient.Config{
-			K8sExtClient: extClient,
-			Logger:       config.Logger,
-		}
-
-		crdClient, err = k8scrdclient.New(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var ctrlClient client.Client
-	{
-		if config.SchemeBuilder != nil {
-			// Extend the global client-go scheme which is used by all the tools under
-			// the hood. The scheme is required for the controller-runtime controller to
-			// be able to watch for runtime objects of a certain type.
-			schemeBuilder := runtime.SchemeBuilder(config.SchemeBuilder)
-
-			err = schemeBuilder.AddToScheme(scheme.Scheme)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-		}
-
-		ctrlClient = clientfake.NewFakeClientWithScheme(scheme.Scheme, objects...)
-	}
-
-	var dynClient dynamic.Interface
-	{
-		dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme, objects...)
-	}
-
-	var g8sClient versioned.Interface
-	{
-		g8sClient = versionedfake.NewSimpleClientset()
-	}
-
-	var k8sClient kubernetes.Interface
-	{
-		k8sClient = kubernetesfake.NewSimpleClientset(objects...)
-	}
-
-	c := &Clients{
-		logger: config.Logger,
-
-		crdClient:  crdClient,
-		ctrlClient: ctrlClient,
-		dynClient:  dynClient,
-		extClient:  extClient,
-		g8sClient:  g8sClient,
-		k8sClient:  k8sClient,
-		restConfig: restConfig,
-	}
-
-	return c, nil
 }
 
 func NewClients(config ClientsConfig) (*Clients, error) {

--- a/pkg/k8sclient/fake/clients.go
+++ b/pkg/k8sclient/fake/clients.go
@@ -1,0 +1,148 @@
+package fake
+
+import (
+	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
+	versionedfake "github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned/fake"
+	"github.com/giantswarm/microerror"
+	"github.com/giantswarm/micrologger"
+	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
+	"k8s.io/client-go/kubernetes"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
+	"github.com/giantswarm/k8sclient/v4/pkg/k8scrdclient"
+)
+
+type Clients struct {
+	logger micrologger.Logger
+
+	crdClient  k8scrdclient.Interface
+	ctrlClient client.Client
+	dynClient  dynamic.Interface
+	extClient  apiextensionsclient.Interface
+	g8sClient  versioned.Interface
+	k8sClient  kubernetes.Interface
+	restClient rest.Interface
+	restConfig *rest.Config
+}
+
+func NewClients(config k8sclient.ClientsConfig, objects ...runtime.Object) (*Clients, error) {
+	if config.Logger == nil {
+		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
+	}
+
+	var err error
+
+	var restConfig *rest.Config
+	{
+		restConfig = config.RestConfig
+	}
+
+	var extClient apiextensionsclient.Interface
+	{
+		extClient = apiextensionsclientfake.NewSimpleClientset()
+	}
+
+	var crdClient *k8scrdclient.CRDClient
+	{
+		c := k8scrdclient.Config{
+			K8sExtClient: extClient,
+			Logger:       config.Logger,
+		}
+
+		crdClient, err = k8scrdclient.New(c)
+		if err != nil {
+			return nil, microerror.Mask(err)
+		}
+	}
+
+	var ctrlClient client.Client
+	{
+		if config.SchemeBuilder != nil {
+			// Extend the global client-go scheme which is used by all the tools under
+			// the hood. The scheme is required for the controller-runtime controller to
+			// be able to watch for runtime objects of a certain type.
+			schemeBuilder := runtime.SchemeBuilder(config.SchemeBuilder)
+
+			err = schemeBuilder.AddToScheme(scheme.Scheme)
+			if err != nil {
+				return nil, microerror.Mask(err)
+			}
+		}
+
+		ctrlClient = clientfake.NewFakeClientWithScheme(scheme.Scheme, objects...)
+	}
+
+	var dynClient dynamic.Interface
+	{
+		dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme, objects...)
+	}
+
+	var g8sClient versioned.Interface
+	{
+		g8sClient = versionedfake.NewSimpleClientset()
+	}
+
+	var k8sClient kubernetes.Interface
+	{
+		k8sClient = kubernetesfake.NewSimpleClientset(objects...)
+	}
+
+	c := &Clients{
+		logger: config.Logger,
+
+		crdClient:  crdClient,
+		ctrlClient: ctrlClient,
+		dynClient:  dynClient,
+		extClient:  extClient,
+		g8sClient:  g8sClient,
+		k8sClient:  k8sClient,
+		restConfig: restConfig,
+	}
+
+	return c, nil
+}
+
+func (c *Clients) CRDClient() k8scrdclient.Interface {
+	return c.crdClient
+}
+
+func (c *Clients) CtrlClient() client.Client {
+	return c.ctrlClient
+}
+
+func (c *Clients) DynClient() dynamic.Interface {
+	return c.dynClient
+}
+
+func (c *Clients) ExtClient() apiextensionsclient.Interface {
+	return c.extClient
+}
+
+func (c *Clients) G8sClient() versioned.Interface {
+	return c.g8sClient
+}
+
+func (c *Clients) K8sClient() kubernetes.Interface {
+	return c.k8sClient
+}
+
+func (c *Clients) RESTClient() rest.Interface {
+	return c.restClient
+}
+
+func (c *Clients) RESTConfig() *rest.Config {
+	return rest.CopyConfig(c.restConfig)
+}
+
+func (c *Clients) Scheme() *runtime.Scheme {
+	return scheme.Scheme
+}

--- a/pkg/k8sclient/fake/error.go
+++ b/pkg/k8sclient/fake/error.go
@@ -1,0 +1,12 @@
+package fake
+
+import "github.com/giantswarm/microerror"
+
+var invalidConfigError = &microerror.Error{
+	Kind: "invalidConfigError",
+}
+
+// IsInvalidConfig asserts invalidConfigError.
+func IsInvalidConfig(err error) bool {
+	return microerror.Cause(err) == invalidConfigError
+}


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/14999

Add `k8sclient/fake` package which provide a fake clienset suitable for testing.

This is basically a copy of k8sclient/clients.go with some simplification, also the `objects` argument allow to configure fake clients that will respond with the provided objects.
```diff
--- pkg/k8sclient/clients.go	2021-01-12 11:28:29.000000000 +0100
+++ pkg/k8sclient/fake/clients.go	2021-01-12 11:28:29.000000000 +0100
@@ -1,34 +1,26 @@
-package k8sclient
+package fake
 
 import (
 	"github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned"
+	versionedfake "github.com/giantswarm/apiextensions/v2/pkg/clientset/versioned/fake"
 	"github.com/giantswarm/microerror"
 	"github.com/giantswarm/micrologger"
 	apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
+	apiextensionsclientfake "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/dynamic"
+	dynamicfake "k8s.io/client-go/dynamic/fake"
 	"k8s.io/client-go/kubernetes"
+	kubernetesfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/tools/clientcmd"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
 
+	"github.com/giantswarm/k8sclient/v4/pkg/k8sclient"
 	"github.com/giantswarm/k8sclient/v4/pkg/k8scrdclient"
 )
 
-type ClientsConfig struct {
-	Logger micrologger.Logger
-	// SchemeBuilder is an optional way to extend the known types to the global
-	// client-go scheme. Make use of it for custom CRs.
-	SchemeBuilder SchemeBuilder
-
-	// KubeConfigPath and RestConfig are mutually exclusive.
-	KubeConfigPath string
-	// RestConfig and KubeConfigPath are mutually exclusive.
-	RestConfig *rest.Config
-}
-
 type Clients struct {
 	logger micrologger.Logger
 
@@ -42,40 +34,21 @@
 	restConfig *rest.Config
 }
 
-func NewClients(config ClientsConfig) (*Clients, error) {
+func NewClients(config k8sclient.ClientsConfig, objects ...runtime.Object) (*Clients, error) {
 	if config.Logger == nil {
 		return nil, microerror.Maskf(invalidConfigError, "%T.Logger must not be empty", config)
 	}
 
-	if config.KubeConfigPath == "" && config.RestConfig == nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.KubeConfigPath or %T.RestConfig must not be empty", config, config)
-	}
-	if config.KubeConfigPath != "" && config.RestConfig != nil {
-		return nil, microerror.Maskf(invalidConfigError, "%T.KubeConfigPath and %T.RestConfig must not be set at the same time", config, config)
-	}
-
 	var err error
 
 	var restConfig *rest.Config
 	{
-		if config.RestConfig != nil {
-			restConfig = config.RestConfig
-		} else {
-			restConfig, err = clientcmd.BuildConfigFromFlags("", config.KubeConfigPath)
-			if err != nil {
-				return nil, microerror.Mask(err)
-			}
-		}
+		restConfig = config.RestConfig
 	}
 
-	var extClient *apiextensionsclient.Clientset
+	var extClient apiextensionsclient.Interface
 	{
-		c := rest.CopyConfig(restConfig)
-
-		extClient, err = apiextensionsclient.NewForConfig(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
+		extClient = apiextensionsclientfake.NewSimpleClientset()
 	}
 
 	var crdClient *k8scrdclient.CRDClient
@@ -105,63 +78,22 @@
 			}
 		}
 
-		// Configure a dynamic rest mapper to the controller client so it can work
-		// with runtime objects of arbitrary types. Note that this is the default
-		// for controller clients created by controller-runtime managers.
-		// Anticipating a rather uncertain future and more breaking changes to come
-		// we want to separate client and manager. Thus we configure the client here
-		// properly on our own instead of relying on the manager to provide a
-		// client, which might change in the future.
-		mapper, err := apiutil.NewDynamicRESTMapper(rest.CopyConfig(restConfig))
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-
-		ctrlClient, err = client.New(rest.CopyConfig(restConfig), client.Options{Scheme: scheme.Scheme, Mapper: mapper})
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
+		ctrlClient = clientfake.NewFakeClientWithScheme(scheme.Scheme, objects...)
 	}
 
 	var dynClient dynamic.Interface
 	{
-		c := rest.CopyConfig(restConfig)
-
-		dynClient, err = dynamic.NewForConfig(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
+		dynClient = dynamicfake.NewSimpleDynamicClient(scheme.Scheme, objects...)
 	}
 
-	var g8sClient *versioned.Clientset
+	var g8sClient versioned.Interface
 	{
-		c := rest.CopyConfig(restConfig)
-
-		g8sClient, err = versioned.NewForConfig(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
-	}
-
-	var k8sClient *kubernetes.Clientset
-	{
-		c := rest.CopyConfig(restConfig)
-
-		k8sClient, err = kubernetes.NewForConfig(c)
-		if err != nil {
-			return nil, microerror.Mask(err)
-		}
+		g8sClient = versionedfake.NewSimpleClientset()
 	}
 
-	var restClient rest.Interface
+	var k8sClient kubernetes.Interface
 	{
-		// It would be cool to use rest.RESTClientFor here but it fails
-		// because GroupVersion is not configured. So underlying core
-		// RESTClient is taken.
-		//
-		//	panic: GroupVersion is required when initializing a RESTClient
-		//
-		restClient = k8sClient.RESTClient()
+		k8sClient = kubernetesfake.NewSimpleClientset(objects...)
 	}
 
 	c := &Clients{
@@ -173,7 +105,6 @@
 		extClient:  extClient,
 		g8sClient:  g8sClient,
 		k8sClient:  k8sClient,
-		restClient: restClient,
 		restConfig: restConfig,
 	}
```

There's an example of this being used here: https://github.com/giantswarm/prometheus-meta-operator/pull/261/files#diff-896a388557c7f19cde35473f7864e7aa61a5e2ad432b497e66e1fbc623819835R56

## Checklist

- [x] Update changelog in CHANGELOG.md.
