### PR TITLE
Make linter happy wrt a deprecation in controller-runtime

### DIFF
--- a/pkg/k8sclient/fake/clients.go
+++ b/pkg/k8sclient/fake/clients.go
@@ -15,7 +15,7 @@ import (
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck // v0.6.4 has a deprecation on pkg/client/fake that was removed in later versions
 
 	"github.com/giantswarm/k8sclient/v5/pkg/k8sclient"
 	"github.com/giantswarm/k8sclient/v5/pkg/k8scrdclient"


### PR DESCRIPTION
controller-runtime v0.6.4 has a deprecation on `pkg/client/fake` which
makes `golangci-lint` complain. This deprecation was reversed as per
https://github.com/kubernetes-sigs/controller-runtime/issues/768 and
no longer exists in later releases.

Add a `nolint` tag to skip this check until we update to a newer
`controller-runtime`.

## Checklist

- [ ] Update changelog in CHANGELOG.md.
