### PR TITLE
prepare v7 release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/giantswarm/k8sclient/v6
+module github.com/giantswarm/k8sclient/v7
 
 go 1.17
 
@@ -56,5 +56,7 @@ require (
 
 replace (
 	github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
+	github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient => ./pkg/k8scrdclient
+	github.com/giantswarm/k8sclient/v7/pkg/k8sversion => ./pkg/k8sversion
 	github.com/spf13/viper => github.com/spf13/viper v1.9.0
 )

--- a/go.mod
+++ b/go.mod
@@ -56,7 +56,5 @@ require (
 
 replace (
 	github.com/dgrijalva/jwt-go => github.com/dgrijalva/jwt-go/v4 v4.0.0-preview1
-	github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient => ./pkg/k8scrdclient
-	github.com/giantswarm/k8sclient/v7/pkg/k8sversion => ./pkg/k8sversion
 	github.com/spf13/viper => github.com/spf13/viper v1.9.0
 )

--- a/pkg/k8sclient/clients.go
+++ b/pkg/k8sclient/clients.go
@@ -16,7 +16,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/apiutil"
 
-	"github.com/giantswarm/k8sclient/v6/pkg/k8scrdclient"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient"
 )
 
 type ClientsConfig struct {

--- a/pkg/k8sclient/fake/clients.go
+++ b/pkg/k8sclient/fake/clients.go
@@ -15,7 +15,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	clientfake "sigs.k8s.io/controller-runtime/pkg/client/fake" //nolint:staticcheck // v0.6.4 has a deprecation on pkg/client/fake that was removed in later versions
 
-	"github.com/giantswarm/k8sclient/v6/pkg/k8sclient"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 )
 
 type Clients struct {

--- a/pkg/k8sclient/spec.go
+++ b/pkg/k8sclient/spec.go
@@ -8,7 +8,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/k8sclient/v6/pkg/k8scrdclient"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient"
 )
 
 type Interface interface {

--- a/pkg/k8sclienttest/clients.go
+++ b/pkg/k8sclienttest/clients.go
@@ -9,7 +9,7 @@ import (
 	"k8s.io/client-go/rest"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	"github.com/giantswarm/k8sclient/v6/pkg/k8scrdclient"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8scrdclient"
 )
 
 type ClientsConfig struct {

--- a/pkg/k8scrdclient/crd_client.go
+++ b/pkg/k8scrdclient/crd_client.go
@@ -12,7 +12,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
-	"github.com/giantswarm/k8sclient/v6/pkg/k8sversion"
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sversion"
 )
 
 type Config struct {

--- a/pkg/k8srestconfig/rest_config.go
+++ b/pkg/k8srestconfig/rest_config.go
@@ -8,7 +8,7 @@
 //		"k8s.io/client-go/rest"
 //		apiextensionsclient "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 //
-//		"github.com/giantswarm/k8sclient/v6/pkg/k8srestconfig"
+//		"github.com/giantswarm/k8sclient/v7/pkg/k8srestconfig"
 //		"github.com/giantswarm/microerror"
 //	)
 //


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20186

I am bumping the major version here due to giantswarm/backoff major version bump and the underlying bump for github.com/cenkalti/backoff from v2.2.1 to v4.0.2

It hard to tell what changed as theres no upstream changelog, but here is the git log between the 2 versions.

```
$ git log --oneline v4.0.1...v2.2.1
78afdac (tag: v4.0.1) Fix crash if nil passed to NewTickerWithTimer
e13aad9 Fix documentation on getRandomValueFromInterval
a9a4cec (tag: v4.0.0) require minimum go 1.12
6e2a5d4 v4
e6c7b7c Merge branch 'venkatraju-venkat_custom_stop' into v4
c11c1b5 Merge branch 'venkat_custom_stop' of git://github.com/venkatraju/backoff into venkatraju-venkat_custom_stop
3832ace fix zero WithMaxRetries case; fix #80
83c9244 (tag: v3.2.1) Merge branch 'justin-mp-v3' into v3
5fa5292 Merge branch 'v3' of git://github.com/justin-mp/backoff into justin-mp-v3
0a81bfb (tag: v3.2.0) Merge branch 'Oppodelldog-v3' into v3; fix #74
e2a99b5 fix flaky ticker test
cd75922 unexport DefaultTimer
f321e50 refactor; move Timer to its own file
842771f provide custom timer in tests to speed up
4a7b172 add NewTickerWithTimer function
18ebfa5 Merge branch 'v3' of git://github.com/Oppodelldog/backoff into Oppodelldog-v3
1357787 (tag: v3.1.2) respect context in WithMaxTries; fix #86
effd0e4 Abstract timer corresponding logic towards an interface to enable  user defined timer behavior. By default time.Timer is used as timer.
671f609 add support for custom Stop duration in ExponentialBackOff
20d3657 Merge pull request #1 from justin-mp/justin-mp-patch-1
f1b5cc7 Return context error from RetryNotify when done
1ff1c09 (tag: v3.1.1) time.Until not available in go 1.7
0e8b8a8 (tag: v3.1.0) update ExponentialBackOff.Reset docs; fix #69
8e09ea4 simplify next backoff formula in comments
b715797 fix various linter warnings
457569c PermanentError implements Unwrap; fix #79
4cc3abf add import path to readme; fix #78
5267b6d (tag: v2.2.1, origin/v2) remove go.mod file #76
4b4ceba (tag: v3.0.0) add /v3 to module path
```