### PR TITLE
add k8sclient/fake.TestInterface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fix k8sclient/fake missing `CRDClient()` method.
+
 ## [7.0.0] - 2021-12-17
 
 ### Changed

--- a/pkg/k8sclient/fake/clients_test.go
+++ b/pkg/k8sclient/fake/clients_test.go
@@ -1,0 +1,41 @@
+package fake
+
+import (
+	"testing"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
+	"github.com/giantswarm/micrologger"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+)
+
+// TestInterface make sure Clients struct is compatible with k8sClient.Interface.
+func TestInterface(t *testing.T) {
+	var err error
+
+	var logger micrologger.Logger
+	{
+		c := micrologger.Config{}
+
+		logger, err = micrologger.New(c)
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	var k8sClient k8sclient.Interface
+	{
+		c := k8sclient.ClientsConfig{
+			Logger:        logger,
+			SchemeBuilder: k8sclient.SchemeBuilder(appsv1.SchemeBuilder),
+		}
+
+		k8sClient, err = NewClients(c, &corev1.Node{})
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Needed to avoid: k8sClient declared but not used error.
+	k8sClient.RESTClient()
+}

--- a/pkg/k8sclient/fake/clients_test.go
+++ b/pkg/k8sclient/fake/clients_test.go
@@ -3,10 +3,11 @@ package fake
 import (
 	"testing"
 
-	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 	"github.com/giantswarm/micrologger"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+
+	"github.com/giantswarm/k8sclient/v7/pkg/k8sclient"
 )
 
 // TestInterface make sure Clients struct is compatible with k8sClient.Interface.


### PR DESCRIPTION
Towards: https://github.com/giantswarm/giantswarm/issues/20186

Fixing a bug in k8sclient/fake which is missing the `CRDClient()` method.